### PR TITLE
feature: adds terraform root module workflows

### DIFF
--- a/.github/workflows/terraform-module-release.yml
+++ b/.github/workflows/terraform-module-release.yml
@@ -21,27 +21,27 @@ permissions:
   contents: write
 
 jobs:
-  # deploy:
-  #   name: Deploy to S3
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
+  deploy:
+    name: Deploy to S3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-  #     - name: Authenticate AWS CLI
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         role-to-assume: ${{ secrets.deploy-role-arn }}
-  #         aws-region: ${{ inputs.aws-region }}
+      - name: Authenticate AWS CLI
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.deploy-role-arn }}
+          aws-region: ${{ inputs.aws-region }}
 
-  #     - name: Build Module Archive File
-  #       run: make module.package
+      - name: Build Module Archive File
+        run: make module.package
 
-  #     - name: Deploy to S3 Registry
-  #       run: |
-  #         MODULE_VERSION=$(cat VERSION)
-  #         aws s3 cp .build/$MODULE_VERSION.zip \
-  #           s3://knox.us-east-2.tfmodule-registry/${{ inputs.module-name }}/$MODULE_VERSION.zip
+      - name: Deploy to S3 Registry
+        run: |
+          MODULE_VERSION=$(cat VERSION)
+          aws s3 cp .build/$MODULE_VERSION.zip \
+            s3://knox.us-east-2.tfmodule-registry/${{ inputs.module-name }}/$MODULE_VERSION.zip
 
   tag_repo:
     name: Tag Repo
@@ -64,18 +64,3 @@ jobs:
               ref: `refs/tags/${repoTag}`,
               sha: context.sha
             });
-
-# var repoTag = fs.readFile("VERSION", (err, data) => {
-#   if (err) throw err;
-
-#   var version = data.toString().trim();
-#   var repoTag = `refs/tags/${version}`;
-
-#   github.rest.git.createRef({
-#     owner: context.repo.owner,
-#     repo: context.repo.repo,
-#     ref: repoTag,
-#     sha: context.sha
-#   });
-# });
-

--- a/.github/workflows/terraform-module-release.yml
+++ b/.github/workflows/terraform-module-release.yml
@@ -56,17 +56,26 @@ jobs:
           script: |
             const fs = require("fs");
 
-            var repoTag = fs.readFile("VERSION", (err, data) => {
-              if (err) throw err;
+            var repoTag = fs.readFileSync('VERSION', {encoding: 'utf8'}).trim();
 
-              var version = data.toString().trim();
-              var repoTag = `refs/tags/${version}`;
-
-              github.rest.git.createRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: repoTag,
-                sha: context.sha
-              });
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${repoTag}`,
+              sha: context.sha
             });
+
+# var repoTag = fs.readFile("VERSION", (err, data) => {
+#   if (err) throw err;
+
+#   var version = data.toString().trim();
+#   var repoTag = `refs/tags/${version}`;
+
+#   github.rest.git.createRef({
+#     owner: context.repo.owner,
+#     repo: context.repo.repo,
+#     ref: repoTag,
+#     sha: context.sha
+#   });
+# });
 

--- a/.github/workflows/terraform-module-release.yml
+++ b/.github/workflows/terraform-module-release.yml
@@ -21,27 +21,27 @@ permissions:
   contents: write
 
 jobs:
-  deploy:
-    name: Deploy to S3
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+  # deploy:
+  #   name: Deploy to S3
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
 
-      - name: Authenticate AWS CLI
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.deploy-role-arn }}
-          aws-region: ${{ inputs.aws-region }}
+  #     - name: Authenticate AWS CLI
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         role-to-assume: ${{ secrets.deploy-role-arn }}
+  #         aws-region: ${{ inputs.aws-region }}
 
-      - name: Build Module Archive File
-        run: make module.package
+  #     - name: Build Module Archive File
+  #       run: make module.package
 
-      - name: Deploy to S3 Registry
-        run: |
-          MODULE_VERSION=$(cat VERSION)
-          aws s3 cp .build/$MODULE_VERSION.zip \
-            s3://knox.us-east-2.tfmodule-registry/${{ inputs.module-name }}/$MODULE_VERSION.zip
+  #     - name: Deploy to S3 Registry
+  #       run: |
+  #         MODULE_VERSION=$(cat VERSION)
+  #         aws s3 cp .build/$MODULE_VERSION.zip \
+  #           s3://knox.us-east-2.tfmodule-registry/${{ inputs.module-name }}/$MODULE_VERSION.zip
 
   tag_repo:
     name: Tag Repo

--- a/.github/workflows/terraform-root-module-apply.yml
+++ b/.github/workflows/terraform-root-module-apply.yml
@@ -1,0 +1,44 @@
+name: Terraform Root Module Apply Workflow
+
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        type: string
+        description: AWS Region for Terraform state, etc. (i.e. us-east-1).
+        required: true
+    secrets:
+      build-role-arn:
+        description: IAM Role ARN to assume for build-related tasks.
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terraform-apply:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Authenticate AWS CLI
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.build-role-arn }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Plan
+        run: terraform plan -out=apply.plan
+
+      - name: Terraform Apply
+        run: terraform apply apply.plan
+

--- a/.github/workflows/terraform-root-module-build.yml
+++ b/.github/workflows/terraform-root-module-build.yml
@@ -1,0 +1,46 @@
+name: Terraform Root Module Build Workflow
+
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        type: string
+        description: AWS Region for Terraform state, etc. (i.e. us-east-1).
+        required: true
+      run-plan:
+        type: boolean
+        description: Boolean indicating whether or not to run 'terraform plan'.
+        required: false
+        default: true
+    secrets:
+      build-role-arn:
+        description: IAM Role ARN to assume for build-related tasks.
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  lint-tasks:
+    name: Lint Tasks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Authenticate AWS CLI
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.build-role-arn }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Run CI Tasks
+        run: make module.ci
+
+      - name: Terraform Plan
+        if: ${{ inputs.run-plan }}
+        run: terraform plan -out=apply.plan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,22 @@
 _The following sections summarize the changes made throughout this project and the approximate date each of the changes_
 _were made._
 
+## [09/27/2022]
+
+* `terraform-root-module-build.yml`
+  * Workflow introduced to perform typical CI/CD tasks such as module linting, security checks and `terraform plan`
+    to identify the infrastructure changes to be performed during a `terraform apply`.
+* `terraform-root-module-apply.yml`
+  * Workflow introduced to `terraform plan` and `terraform apply` root module infrastructure changes.
+* `terraform-module-release.yml`
+  * Refactored "Tag Repo with VERSION" step with more readable JS.
+
 ## [08/24/2022]
 
 * Initial repository implementation.
-* Terraform Workflows
-  * `terraform-module-build.yml` -- Performs typical CI/CD tasks such as module linting, security checks and apply /
-    destroy operations for `examples/ci`.
-  * `terraform-module-release.yml` -- Performs module release tasks such as copying module package to S3 registry and
+* `terraform-module-build.yml`
+  * Workflow introduced performing typical CI/CD tasks such as module linting, security checks and apply / destroy
+    operations for `examples/ci`.
+* `terraform-module-release.yml`
+  * Workflow introduced performing module release tasks such as copying module package to S3 registry and
     tagging the git repo according to the SemVer within the `VERSION` file.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This repository maintains the shared Github Actions workflows and action steps f
 
 * **_THIS IS A PUBLIC REPOSITORY. BE VERY CAREFUL NOT TO EXPOSE SENSITIVE ORGANIZATIONAL DETAILS SUCH AS ACCOUNT_**
   **_NUMBERS, ETC. THESE ITEMS SHOULD BE PROVIDED VIA SECRETS VARIABLES AND INJECTED VIA PRIVATE CALLER WORKFLOWS._**
-* Currently, GitHub requires that shared workflows in remote repositories maintain the same `.github` directory
-  structure as if the workflow existed in the calling repository. It would be helpful to organize workflows in various
-  subdirectories based on tech stack. However, reusable workflows and actions exist in `.github/workflows` and
-  `.github/actions` respectively.
+* It would be helpful to organize the workflows and actions within this repository by subdirectory based on associated
+  tech stack. However, GitHub requires that shared workflows in remote repositories maintain the same `.github`
+  directory structure as if the workflow existed in the calling repository. Therefore, the reusable actions and
+  workflows in this repository must exist in the `.github/actions` and `.github/workflows` directories respectively.
 
 ## Usage
 


### PR DESCRIPTION
## [09/27/2022]

* `terraform-root-module-build.yml`
  * Workflow introduced to perform typical CI/CD tasks such as module linting, security checks and `terraform plan`
    to identify the infrastructure changes to be performed during a `terraform apply`.
* `terraform-root-module-apply.yml`
  * Workflow introduced to `terraform plan` and `terraform apply` root module infrastructure changes.
* `terraform-module-release.yml`
  * Refactored "Tag Repo with VERSION" step with more readable JS.