### PR TITLE
fix: terraform-root-module-build missing 'terraform init'

### DIFF
--- a/.github/workflows/terraform-root-module-build.yml
+++ b/.github/workflows/terraform-root-module-build.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Terraform Plan
         if: ${{ inputs.run-plan }}
-        run: terraform plan -out=apply.plan
+        run: terraform init && terraform plan -out=apply.plan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 _The following sections summarize the changes made throughout this project and the approximate date each of the changes_
 _were made._
 
+## [11/21/2022]
+
+* `terraform-root-module-build.yml`
+  * Fixes missing `terraform init` call in "Terraform Plan" step.
+
 ## [09/27/2022]
 
 * `terraform-root-module-build.yml`


### PR DESCRIPTION
## [11/21/2022]

* `terraform-root-module-build.yml`
  * Fixes missing `terraform init` call in "Terraform Plan" step.